### PR TITLE
fix support search multiple documents

### DIFF
--- a/classes/BasePageIndex.php
+++ b/classes/BasePageIndex.php
@@ -124,4 +124,14 @@ class BasePageIndex extends Model
         $class = str_replace('\\', '', static::class);
         return $this->arraySourceGetDbDir() . '/docs-' . Str::slug(str_replace('.', '-', static::$pageList->getDocsIdentifier())) . '.sqlite';
     }
+    
+    /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return $this->table ?? str_replace('.', '_', static::$pageList->getDocsIdentifier());
+    }
 }


### PR DESCRIPTION
fix when there are multiple documents, the search only supports one document。 because the table is `Str::snake(Str::pluralStudly(class_basename($this)))`

```
    /**
     * Get the table associated with the model.
     *
     * @return string
     */
    public function getTable()
    {
        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
    }
```

modify to 

```
    /**
     * Get the table associated with the model.
     *
     * @return string
     */
    public function getTable()
    {
        return $this->table ?? str_replace('.', '_', static::$pageList->getDocsIdentifier());
    }
}
```
