### PR TITLE
fix support search multiple documents

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -92,11 +92,13 @@ class Plugin extends PluginBase
                 'name' => $doc['name'],
                 'model' => function () use ($doc) {
                     if ($doc['instance'] instanceof MarkdownDocumentation) {
+                        MarkdownPageIndex::clearBootedModels();
                         MarkdownPageIndex::setPageList($doc['instance']->getPageList());
 
                         return new MarkdownPageIndex();
                     }
 
+                    PHPApiPageIndex::clearBootedModels();
                     PHPApiPageIndex::setPageList($doc['instance']->getPageList());
 
                     return new PHPApiPageIndex();

--- a/classes/BasePageIndex.php
+++ b/classes/BasePageIndex.php
@@ -124,4 +124,14 @@ class BasePageIndex extends Model
         $class = str_replace('\\', '', static::class);
         return $this->arraySourceGetDbDir() . '/docs-' . Str::slug(str_replace('.', '-', static::$pageList->getDocsIdentifier())) . '.sqlite';
     }
+
+     /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return $this->table ?? str_replace('.', '_', static::$pageList->getDocsIdentifier());
+    }
 }


### PR DESCRIPTION
fix when there are multiple documents, the search only supports one document。 because the table is `Str::snake(Str::pluralStudly(class_basename($this)))`

```
    /**
     * Get the table associated with the model.
     *
     * @return string
     */
    public function getTable()
    {
        return $this->table ?? Str::snake(Str::pluralStudly(class_basename($this)));
    }
```

modify to 

```
    /**
     * Get the table associated with the model.
     *
     * @return string
     */
    public function getTable()
    {
        return $this->table ?? str_replace('.', '_', static::$pageList->getDocsIdentifier());
    }
}
```

other the `Winter\Storm\Database\Traits\ArraySource` , it only boot once , so the $arraySourceConnection is first document sqlite connect。

it need to clear the boot when have other document in `Plugin.php`

```
 MarkdownPageIndex::clearBootedModels();

 PHPApiPageIndex::clearBootedModels();

```

I think getTable is can not change  when $arraySourceConnection is  dynamic ,but it is not work when seach。

so modify `getTable` and `clearBootedModels`
